### PR TITLE
Fix style of the decoded string for union/struct when the fields is empty

### DIFF
--- a/Sources/ObjCTypeDecodeKit/Model/ObjCType.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCType.swift
@@ -105,9 +105,9 @@ extension ObjCType: ObjCTypeDecodable {
         case .bitField(let width):
             return "int x : \(width)"
         case .union(let name, let fields):
-            guard let fields else {
+            guard let fields, !fields.isEmpty else {
                 if let name {
-                    return name
+                    return "union \(name)"
                 } else {
                     return "union {}"
                 }
@@ -135,9 +135,9 @@ extension ObjCType: ObjCTypeDecodable {
                 """
             }
         case .struct(let name, let fields):
-            guard let fields else {
+            guard let fields, !fields.isEmpty else {
                 if let name {
-                    return name
+                    return "struct \(name)"
                 } else {
                     return "struct {}"
                 }

--- a/Tests/ObjCTypeDecodeKitTests/ObjCTypeDecodeKitTests.swift
+++ b/Tests/ObjCTypeDecodeKitTests/ObjCTypeDecodeKitTests.swift
@@ -182,7 +182,7 @@ final class ObjCTypeDecodeKitTests: XCTestCase {
             decoded("^AQ"),
             "_Atomic unsigned long long *"
         )
-        XCTAssertEqual(decoded("^A{CGPoint}"), "_Atomic CGPoint *")
+        XCTAssertEqual(decoded("^A{CGPoint}"), "_Atomic struct CGPoint *")
     }
 
     func testComplex() {


### PR DESCRIPTION
closes #3 