### PR TITLE
Prefer `BOOL` to `char`/`unsigned char` for header string

### DIFF
--- a/Sources/ObjCDump/Extension/ObjCType+.swift
+++ b/Sources/ObjCDump/Extension/ObjCType+.swift
@@ -26,9 +26,13 @@ extension ObjCType {
                 let type: ObjCType = .union(name: nil, fields: field)
                 return type.decoded(tab: "")
             }
+        case .char: fallthrough
+        case .uchar:
+            return "BOOL"
         default:
             break
         }
+        
         return decoded(tab: "")
             .components(separatedBy: .newlines)
             .joined(separator: " ")

--- a/Sources/ObjCDump/Extension/ObjCType+.swift
+++ b/Sources/ObjCDump/Extension/ObjCType+.swift
@@ -26,6 +26,9 @@ extension ObjCType {
                 let type: ObjCType = .union(name: nil, fields: field)
                 return type.decoded(tab: "")
             }
+        // Objective-C BOOL types may be represented by signed char or by C/C++ bool types.
+        // This means that the type encoding may be represented as C(c) or as B.
+        // [reference](https://github.com/apple-oss-distributions/objc4/blob/01edf1705fbc3ff78a423cd21e03dfc21eb4d780/runtime/objc.h#L61-L86)
         case .char: fallthrough
         case .uchar:
             return "BOOL"

--- a/Sources/ObjCDump/Model/ObjCIvarInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCIvarInfo.swift
@@ -64,13 +64,27 @@ extension ObjCIvarInfo {
                 name: name,
                 bitWidth: width
             )
-            return field.decoded(fallbackName: name)
+            return field.decodedForHeader(fallbackName: name)
         } else {
+            if [.char, .uchar].contains(type) {
+                return "BOOL \(name)"
+            }
             let type = type?.decoded()
             if let type, type.last == "*" {
                 return "\(type)\(name);"
             }
             return "\(type ?? "unknown") \(name);"
         }
+    }
+}
+
+extension ObjCField {
+    func decodedForHeader(
+        fallbackName: String, tab: String = "    "
+    ) -> String  {
+        if [.char, .uchar].contains(type) {
+            return "BOOL \(name ?? fallbackName);"
+        }
+        return decoded(fallbackName: fallbackName, tab: tab)
     }
 }


### PR DESCRIPTION
closes #4 