### PR TITLE
Make objc models conform to Sendable

### DIFF
--- a/Sources/ObjCDump/Model/ObjCCategoryInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCCategoryInfo.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Structure for representing objc category information.
-public struct ObjCCategoryInfo {
+public struct ObjCCategoryInfo: Sendable {
     /// Name of the category
     public let name: String
 

--- a/Sources/ObjCDump/Model/ObjCClassInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCClassInfo.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Structure for representing objc class information.
-public struct ObjCClassInfo {
+public struct ObjCClassInfo: Sendable {
     /// Name of the class
     public let name: String
     /// Version of the class

--- a/Sources/ObjCDump/Model/ObjCIvarInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCIvarInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 import ObjCTypeDecodeKit
 
 /// Structure for representing objc instance variable information.
-public struct ObjCIvarInfo {
+public struct ObjCIvarInfo: Sendable {
     /// Name of the Ivar
     public let name: String
     /// Encoded type of the Ivar

--- a/Sources/ObjCDump/Model/ObjCMethodInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCMethodInfo.swift
@@ -11,7 +11,7 @@ import ObjCTypeDecodeKit
 
 /// Structure for representing objc method information.
 @dynamicMemberLookup
-public struct ObjCMethodInfo {
+public struct ObjCMethodInfo: Sendable {
     /// Name of the method
     public let name: String
     /// Encoded method type of the method

--- a/Sources/ObjCDump/Model/ObjCPropertyInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCPropertyInfo.swift
@@ -10,7 +10,7 @@ import Foundation
 import ObjCTypeDecodeKit
 
 /// Structure for representing objc property information.
-public struct ObjCPropertyInfo {
+public struct ObjCPropertyInfo: Sendable {
     /// Name of the property
     public let name: String
     /// Attributes string of the property

--- a/Sources/ObjCDump/Model/ObjCProtocolInfo.swift
+++ b/Sources/ObjCDump/Model/ObjCProtocolInfo.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// Structure for representing objc protocol information.
-public struct ObjCProtocolInfo {
+public struct ObjCProtocolInfo: Sendable {
     /// Name of the protocol
     public let name: String
 

--- a/Sources/ObjCTypeDecodeKit/Model/Node.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/Node.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct Node {
+public struct Node: Sendable {
     public var decoded: ObjCType?
     public var trailing: String?
 }

--- a/Sources/ObjCTypeDecodeKit/Model/ObjCField.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCField.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public struct ObjCField: Equatable {
+public struct ObjCField: Sendable, Equatable {
     public let type: ObjCType
     public var name: String?
     public var bitWidth: Int?

--- a/Sources/ObjCTypeDecodeKit/Model/ObjCMethodType.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCMethodType.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-public struct ObjCMethodType {
-    public struct ArgumentInfo {
+public struct ObjCMethodType: Sendable {
+    public struct ArgumentInfo: Sendable {
         public let type: ObjCType
         public let offset: Int
     }

--- a/Sources/ObjCTypeDecodeKit/Model/ObjCModifier.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCModifier.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public enum ObjCModifier: CaseIterable, Equatable {
+public enum ObjCModifier: CaseIterable, Sendable, Equatable {
     case complex
     case atomic
     case const

--- a/Sources/ObjCTypeDecodeKit/Model/ObjCPropertyAttribute.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCPropertyAttribute.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 // https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/ObjCRuntimeGuide/Articles/ocrtPropertyIntrospection.html#//apple_ref/doc/uid/TP40008048-CH101-SW1
-public enum ObjCPropertyAttribute: Equatable {
+public enum ObjCPropertyAttribute: Sendable, Equatable {
     case type(ObjCType?) // T
     case readonly // R
     case copy // C

--- a/Sources/ObjCTypeDecodeKit/Model/ObjCType.swift
+++ b/Sources/ObjCTypeDecodeKit/Model/ObjCType.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-public indirect enum ObjCType: Equatable {
+public indirect enum ObjCType: Sendable, Equatable {
     case `class`
     case selector
 


### PR DESCRIPTION
- Updated ObjCCategoryInfo, ObjCClassInfo, ObjCIvarInfo, ObjCMethodInfo, ObjCPropertyInfo, ObjCProtocolInfo, Node, ObjCField, ObjCMethodType, ObjCModifier, ObjCPropertyAttribute, and ObjCType to conform to Sendable.